### PR TITLE
Rewrite backend: provider-agnostic AI layer (Claude + Imagen 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# --- Text generation (Anthropic Claude) ---
+ANTHROPIC_API_KEY=sk-ant-...
+# Optional: defaults to claude-sonnet-4-6. Drop to claude-haiku-4-5 for the
+# lowest cost, or claude-opus-4-8 for max quality.
+# TEXT_MODEL=claude-haiku-4-5
+
+# --- Image generation (Google Imagen 4) ---
+GOOGLE_API_KEY=...
+# Optional: defaults to imagen-4.0-generate-001
+# IMAGE_MODEL=imagen-4.0-generate-001
+
+# --- Provider selection (rarely changed; here for the abstraction layer) ---
+# TEXT_PROVIDER=anthropic
+# IMAGE_PROVIDER=google

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Secrets — never commit
+.env
+.env.*
+!.env.example
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/
+
+# Vercel
+.vercel

--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
 # chatlibs-flask
 
-a chatlibs flask implementation
+A Mad-Libs–meets-AI children's story generator. Pick a topic, the AI writes a
+silly 75-word story, you supply six words blind, the AI swaps them into the
+story, and you get an illustrated, shareable result.
+
+This is a ground-up rewrite of the original. The front end (look, fonts, flow,
+mobile behavior) is unchanged; the backend is new.
+
+## Architecture
+
+- **Flask** app (`api/index.py`), deployable as a Vercel serverless function.
+- **Provider-agnostic AI layer** (`api/ai.py`): text and image generation each
+  dispatch to a pluggable backend chosen by env var. Today: Anthropic Claude
+  (text) + Google Imagen 4 (image). Swapping models/vendors is a config change.
+- **Config-driven flow** (`api/flow.py`): the steps, prompts, and word slots
+  live in one data structure served to the client at `/api/config`. The browser
+  orchestrates the flow off that config — change the game design in one place.
+- **Stateless endpoints**: `/api/story`, `/api/title`, `/api/remix`,
+  `/api/image` each wrap one AI call and return a uniform JSON envelope with
+  real error handling. `/` and `/story` render the two pages.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env   # fill in ANTHROPIC_API_KEY and GOOGLE_API_KEY
+```
+
+The static image assets (`chatlibs-logo.png`, `chatlibs-share.png`,
+`donors-choose-ad.png`) carry over from the original repo — keep them in
+`api/static/`.
+
+## Run locally
+
+```bash
+export $(grep -v '^#' .env | xargs)   # or use your preferred env loader
+python api/index.py
+# open http://localhost:5000
+```
+
+## Configuration
+
+| Env var          | Default                   | Notes |
+|------------------|---------------------------|-------|
+| `ANTHROPIC_API_KEY` | —                      | required for text |
+| `TEXT_MODEL`     | `claude-sonnet-4-6`       | `claude-haiku-4-5` is cheaper; `claude-opus-4-8` is max quality |
+| `GOOGLE_API_KEY` | —                         | required for image (`GEMINI_API_KEY` also accepted) |
+| `IMAGE_MODEL`    | `imagen-4.0-generate-001` | |
+| `TEXT_PROVIDER`  | `anthropic`               | |
+| `IMAGE_PROVIDER` | `google`                  | |
+
+## Notes
+
+- Images are returned as `data:` URIs and shown in-app only (ephemeral, by
+  design). The shareable `/story` page carries the title and story text; its
+  social-preview image falls back to the brand share image.

--- a/api/ai.py
+++ b/api/ai.py
@@ -74,6 +74,9 @@ def _google_image(prompt):
     from google import genai
     from google.genai import types
 
+    # Note: negative_prompt is NOT supported on the Gemini Developer API
+    # (API-key mode) — it's Vertex/Enterprise-only and 400s here. Text is kept
+    # out of images via the sanitized scene description built in the route.
     api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
     try:
         client = genai.Client(api_key=api_key)

--- a/api/ai.py
+++ b/api/ai.py
@@ -1,0 +1,98 @@
+"""Provider-agnostic AI layer.
+
+Text and image generation are each dispatched to a pluggable backend selected by
+environment variable, so swapping models or vendors later is a config change, not
+a rewrite. Today: Anthropic Claude for text, Google Imagen 4 for images.
+
+Env vars:
+    TEXT_PROVIDER   default "anthropic"
+    TEXT_MODEL      default "claude-sonnet-4-6" (drop to "claude-haiku-4-5" to
+                    cut cost further, or "claude-opus-4-8" for max quality)
+    ANTHROPIC_API_KEY   required for the anthropic provider
+
+    IMAGE_PROVIDER  default "google"
+    IMAGE_MODEL     default "imagen-4.0-generate-001"
+    GOOGLE_API_KEY  (or GEMINI_API_KEY) required for the google provider
+"""
+
+import base64
+import os
+
+TEXT_PROVIDER = os.getenv("TEXT_PROVIDER", "anthropic")
+TEXT_MODEL = os.getenv("TEXT_MODEL", "claude-sonnet-4-6")
+
+IMAGE_PROVIDER = os.getenv("IMAGE_PROVIDER", "google")
+IMAGE_MODEL = os.getenv("IMAGE_MODEL", "imagen-4.0-generate-001")
+
+
+class AIError(Exception):
+    """Raised for any provider failure; routes turn this into a clean 502."""
+
+
+# --- Text -------------------------------------------------------------------
+
+def generate_text(prompt, system="You are a helpful assistant.", max_tokens=1024):
+    """Generate text from the configured text provider."""
+    if TEXT_PROVIDER == "anthropic":
+        return _anthropic_text(prompt, system, max_tokens)
+    raise AIError(f"Unknown TEXT_PROVIDER: {TEXT_PROVIDER!r}")
+
+
+def _anthropic_text(prompt, system, max_tokens):
+    import anthropic
+
+    try:
+        client = anthropic.Anthropic()  # reads ANTHROPIC_API_KEY from the env
+        # Thinking is left off: these are short, creative completions where
+        # latency matters more than deep reasoning. Flip on adaptive thinking
+        # here if you ever move to a harder text task.
+        resp = client.messages.create(
+            model=TEXT_MODEL,
+            max_tokens=max_tokens,
+            system=system,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except anthropic.APIError as e:
+        raise AIError(f"Claude request failed: {e}") from e
+
+    text = "".join(b.text for b in resp.content if b.type == "text").strip()
+    if not text:
+        raise AIError("Claude returned an empty response.")
+    return text
+
+
+# --- Image ------------------------------------------------------------------
+
+def generate_image(prompt):
+    """Generate an image and return it as a ``data:`` URI for inline display."""
+    if IMAGE_PROVIDER == "google":
+        return _google_image(prompt)
+    raise AIError(f"Unknown IMAGE_PROVIDER: {IMAGE_PROVIDER!r}")
+
+
+def _google_image(prompt):
+    from google import genai
+    from google.genai import types
+
+    api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+    try:
+        client = genai.Client(api_key=api_key)
+        resp = client.models.generate_images(
+            model=IMAGE_MODEL,
+            prompt=prompt,
+            config=types.GenerateImagesConfig(
+                number_of_images=1,
+                output_mime_type="image/jpeg",
+            ),
+        )
+    except Exception as e:  # google-genai raises a variety of error types
+        raise AIError(f"Imagen request failed: {e}") from e
+
+    images = getattr(resp, "generated_images", None) or []
+    if not images:
+        # Most commonly a safety filter blocked the prompt.
+        raise AIError("No image was generated (it may have been filtered).")
+
+    data = images[0].image.image_bytes
+    b64 = base64.b64encode(data).decode("utf-8")
+    return f"data:image/jpeg;base64,{b64}"

--- a/api/flow.py
+++ b/api/flow.py
@@ -1,0 +1,24 @@
+"""The ChatLibs game flow, as data.
+
+The front end fetches this from ``/api/config`` and drives the whole interaction
+off it. Change the game design here — reorder words, add a slot, reword a
+prompt — without touching JavaScript or the route handlers.
+
+`words` order and the 6 slots (3 adjectives / 2 nouns / 1 verb) are the same as
+the original game; the order the user is asked in is A-N-A-V-A-N.
+"""
+
+FLOW = {
+    # Shown when the page loads, before the user types the topic.
+    "intro": "Enter a topic for the story",
+
+    # Collected one at a time, in this order, after the title is revealed.
+    "words": [
+        {"slot": "adjective1", "label": "adjective", "prompt": "Please give me an adjective"},
+        {"slot": "noun1",      "label": "noun",      "prompt": "And a noun"},
+        {"slot": "adjective2", "label": "adjective", "prompt": "How about another adjective"},
+        {"slot": "verb",       "label": "verb",      "prompt": "And a verb"},
+        {"slot": "adjective3", "label": "adjective", "prompt": "Thanks — tell me one more adjective"},
+        {"slot": "noun2",      "label": "noun",      "prompt": "One last noun"},
+    ],
+}

--- a/api/index.py
+++ b/api/index.py
@@ -1,122 +1,129 @@
-from flask import Flask, render_template, request, jsonify
-import os
-import openai
-import requests
+"""ChatLibs — Flask backend.
+
+Four stateless AI endpoints plus the two rendered pages. All game state and flow
+live in the browser (see static/script.js); the flow itself is data (flow.py),
+served to the client at /api/config. Every AI endpoint returns a uniform
+envelope and turns provider failures into a clean JSON error.
+"""
+
+from flask import Flask, jsonify, render_template, request
+
+from ai import AIError, generate_image, generate_text
+from flow import FLOW
 
 app = Flask(__name__)
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
-imageModel = "dall-e-3"
-chatModel = "gpt-4"
 
+def _ai_route(produce):
+    """Run an AI step, always returning JSON so the client never sees a raw 500.
 
-# Assuming you have set OPENAI_API_KEY as an environment variable
-openai.api_key = os.getenv('OPENAI_API_KEY')
-
-@app.route('/')
-def index():
-    return render_template('index.html')
-
-@app.route('/write_story', methods=['POST'])
-def write_story():
-    user_input = request.json['topic']
-    prompt = f"Write a creative, silly 75-word children's story about {user_input}. Include characters, a conflict, rising action, a surprising resolution, and a piece of short dialogue."
+    Provider failures (AIError) and bad input map to clean messages; anything
+    unexpected is logged and returned as a generic 502 rather than an HTML page.
+    """
     try:
-        response = openai.ChatCompletion.create(
-            model=chatModel,
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": prompt}
-            ]
-        )
-    except openai.error.OpenAIError as e:
-        # Handle general OpenAI API errors
-        print(f"An OpenAI API error occurred: {e}")
-    except Exception as e:
-        # Handle other exceptions
-        print(f"A general error occurred: {e}")
-    story_response = {
-        "responseVariableName": "story",
-        "value": response.choices[0].message['content']
-    }
-    return jsonify(story_response)
+        return jsonify(produce())
+    except AIError as e:
+        app.logger.warning("AI step failed: %s", e)
+        return jsonify({"error": str(e)}), 502
+    except (KeyError, TypeError):
+        return jsonify({"error": "Malformed request."}), 400
+    except Exception:  # noqa: BLE001 — API boundary must always return JSON
+        app.logger.exception("Unexpected error in AI step")
+        return jsonify({"error": "Something went wrong. Please try again."}), 502
 
 
-@app.route('/get_title', methods=['POST'])
-def get_title():
-    story = request.json['data']
-    
-    prompt = f"Create a catchy and creative title for this children's story: {story}"
-    
-    response = openai.ChatCompletion.create(
-        model=chatModel,
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": prompt}
-        ]
-    )
+# --- Pages ------------------------------------------------------------------
 
-    title_response = {
-        "responseVariableName": "title",
-        "value": response.choices[0].message['content']
-    }
-    return jsonify(title_response)
+@app.route("/")
+def index():
+    return render_template("index.html")
 
 
-@app.route('/get_image', methods=['POST'])
-def get_image():
-
-    story = request.json['data']
-    PROMPT = (f"Please create an photorealistic image based on this narrative:\n\n{story}\n")
-    response = openai.Image.create(
-        model=imageModel,
-        prompt=PROMPT,
-        n=1,
-        size="1024x1024",
-    )
-
-    imageURL_response = {
-        "responseVariableName": "imageURL",
-        "value": response["data"][0]["url"]
-    }
-    return jsonify(imageURL_response)
-
-
-@app.route('/write_newStory', methods=['POST'])
-def write_newStory():
-    data = request.json
-    original_story = data.get('story')
-    adjective1=data.get('adjective1')
-    adjective2=data.get('adjective2')
-    adjective3=data.get('adjective3')
-    noun1 = data.get('noun1')
-    noun2=data.get('noun2')
-    verb = data.get('verb')
-
-
-    prompt = (f"Integrate the replacement values included below into this original story. Do not change anything in the story other than directly swapping a word of the same part of speech with one of these replacement values.  \n\nOriginal Story:\n{original_story}\n"
-             f"Replacement values to swap into the story:\n{adjective1}\n{adjective2}\n{adjective3}\n{noun1}\n{noun2}\n{verb}\n\n"
-             f"Updated story that includes all the replacement values:")
-    response = openai.ChatCompletion.create(
-        model=chatModel,
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": prompt}
-        ]
-    )
-    story_response = {
-        "responseVariableName": "newStory",
-        "value": response.choices[0].message['content']  
-    }
-    return jsonify(story_response)
-
-@app.route('/story')
+@app.route("/story")
 def story():
-    image_url = request.args.get('image_url', '')
-    title = request.args.get('title', 'Default Title')
-    description = request.args.get('description', 'Default Description')
-    return render_template('story.html', image_url=image_url, title=title, description=description)
+    return render_template(
+        "story.html",
+        image_url=request.args.get("image_url", ""),
+        title=request.args.get("title", "A ChatLibs Story"),
+        description=request.args.get("description", ""),
+    )
 
 
-if __name__ == '__main__':
+# --- Flow config ------------------------------------------------------------
+
+@app.route("/api/config")
+def config():
+    return jsonify(FLOW)
+
+
+# --- AI endpoints -----------------------------------------------------------
+
+@app.route("/api/story", methods=["POST"])
+def write_story():
+    def produce():
+        topic = request.get_json(force=True)["topic"]
+        prompt = (
+            f"Write a creative, silly 75-word children's story about {topic}. "
+            "Include characters, a conflict, rising action, a surprising "
+            "resolution, and a piece of short dialogue. Return only the story."
+        )
+        story_text = generate_text(
+            prompt,
+            system="You are a playful children's story writer.",
+        )
+        return {"story": story_text}
+
+    return _ai_route(produce)
+
+
+@app.route("/api/title", methods=["POST"])
+def get_title():
+    def produce():
+        story_text = request.get_json(force=True)["story"]
+        prompt = (
+            "Create a catchy, creative title for this children's story. "
+            f"Return only the title, with no quotation marks.\n\n{story_text}"
+        )
+        return {"title": generate_text(prompt, max_tokens=64)}
+
+    return _ai_route(produce)
+
+
+@app.route("/api/remix", methods=["POST"])
+def remix_story():
+    def produce():
+        data = request.get_json(force=True)
+        original = data["story"]
+        words = data["words"]  # {slot: value, ...}
+        replacements = "\n".join(f"- {value}" for value in words.values())
+        prompt = (
+            "Integrate the replacement values below into the original story. "
+            "Do not change anything in the story other than directly swapping a "
+            "word of the same part of speech with one of these replacement "
+            "values. Return only the updated story.\n\n"
+            f"Original story:\n{original}\n\n"
+            f"Replacement values to swap in:\n{replacements}"
+        )
+        return {"story": generate_text(prompt)}
+
+    return _ai_route(produce)
+
+
+@app.route("/api/image", methods=["POST"])
+def get_image():
+    def produce():
+        story_text = request.get_json(force=True)["story"]
+        prompt = (
+            "A single whimsical, colorful children's-book illustration depicting "
+            "one cohesive scene from this story. Do NOT include any text, words, "
+            "letters, captions, titles, labels, speech bubbles, or panels — "
+            "purely a wordless picture.\n\n"
+            f"Story:\n{story_text}"
+        )
+        return {"image": generate_image(prompt)}
+
+    return _ai_route(produce)
+
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/api/index.py
+++ b/api/index.py
@@ -6,6 +6,13 @@ served to the client at /api/config. Every AI endpoint returns a uniform
 envelope and turns provider failures into a clean JSON error.
 """
 
+import os
+import sys
+
+# On Vercel the function runs from the project root, so api/ isn't on sys.path
+# and the sibling imports below would fail. Add this file's directory explicitly.
+sys.path.insert(0, os.path.dirname(__file__))
+
 from flask import Flask, jsonify, render_template, request
 
 from ai import AIError, generate_image, generate_text

--- a/api/index.py
+++ b/api/index.py
@@ -120,12 +120,32 @@ def remix_story():
 def get_image():
     def produce():
         story_text = request.get_json(force=True)["story"]
+
+        # First, turn the story into a purely visual scene description — no
+        # dialogue, sound effects, or names. This keeps text the image model
+        # would otherwise render (quotes, "SPLAT!", character names) out of its
+        # input entirely, which matters far more than prompt instructions.
+        describe_prompt = (
+            "You are planning a single illustration for a children's book. "
+            "Based on the story below, write a 2-3 sentence description of one "
+            "visual scene to illustrate. Describe only what is physically "
+            "visible: the characters' appearance, the setting, the action, "
+            "colors, and mood. Do NOT include any dialogue, quotations, sound "
+            "effects, onomatopoeia, character names, signs, or any words meant "
+            "to appear as text. Refer to characters by appearance, not by name. "
+            f"Return only the description.\n\nStory:\n{story_text}"
+        )
+        scene = generate_text(
+            describe_prompt,
+            system="You write concise, vivid visual scene descriptions.",
+            max_tokens=256,
+        )
+
         prompt = (
-            "A single whimsical, colorful children's-book illustration depicting "
-            "one cohesive scene from this story. Do NOT include any text, words, "
-            "letters, captions, titles, labels, speech bubbles, or panels — "
-            "purely a wordless picture.\n\n"
-            f"Story:\n{story_text}"
+            "A single whimsical, colorful children's-book illustration of one "
+            "cohesive scene. The image must contain absolutely no text, words, "
+            "letters, captions, labels, or speech bubbles — a purely wordless "
+            f"picture.\n\nScene: {scene}"
         )
         return {"image": generate_image(prompt)}
 

--- a/api/static/script.js
+++ b/api/static/script.js
@@ -1,237 +1,245 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
     const chatBox = document.getElementById('chat_box');
     const inputField = document.getElementById('input_field');
     const enterButton = document.getElementById('enter_button');
     const returnImage = document.getElementById('return_image');
 
-    let currentStep = 1;
+    let flow = null;          // loaded from /api/config
+    let phase = 'loading';    // loading -> topic -> words -> generating -> done
+    let wordIndex = 0;
     let storyData = {};
 
-    // Prompts for each step
-    const prompts = [
-        "<strong>ChatLibs: </strong>Enter a topic for the story",  
-        "", 
-        "<strong>ChatLibs: </strong>Please give me an adjective",   
-        "<strong>ChatLibs: </strong>And a noun",
-        "<strong>ChatLibs: </strong>How about another adjective",
-        "<strong>ChatLibs: </strong>And a verb",
-        "<strong>ChatLibs: </strong>Thanks — tell me one more adjective",
-        "<strong>ChatLibs: </strong>One last noun",
-        ""
-    ];
+    // --- Chat box helpers ---------------------------------------------------
 
     function updateChatBox(message) {
         chatBox.innerHTML += `<div>${message}<br><br></div>`;
-        chatBox.scrollTop = chatBox.scrollHeight; // Scroll to the bottom
-
+        chatBox.scrollTop = chatBox.scrollHeight;
     }
 
-    function getNextPrompt() {
-        const predefinedInput = "none";
-        if (currentStep <= prompts.length) {
-            switch (currentStep) {
-                case 2:
-                    sendInputToServer(predefinedInput);
-                    break;
-                case 9:
-                    sendInputToServer(predefinedInput);
-                    break;
-                default:
-                    updateChatBox(prompts[currentStep - 1]);
-                    // Change button background back to original and enable it
-                    enterButton.classList.remove('button-waiting');
-                    enterButton.disabled = false;
-                    inputField.disabled = false;
-                    inputField.focus();
-            }
-        }
+    function chatlibsSays(message) {
+        updateChatBox(`<strong>ChatLibs: </strong>${message}`);
     }
 
-
-    function handleResponse(response) {
-        console.log("Handle response");
-        console.log(response);
-
-        if (response.responseVariableName && response.value) {
-            storyData[response.responseVariableName] = response.value;
-        }
-
-        if (response.addToChat) {
-            updateChatBox(response.addToChat);
-        }
-
-        if (currentStep == 2) {
-             updateChatBox("<strong>ChatLibs: </strong>Your story is: <br><strong>"+storyData.title+"</strong>");
-        }
-
-        if (currentStep == 8) {
-             updateChatBox("<br><strong>"+storyData.title+"</strong><br>");
-             emphasizeStoryWords()
-             updateChatBox(storyData.newStoryWithEmphasis);
-        }
-     
-        if (currentStep == 9) {
-             returnImage.src = storyData.imageURL; // Update the return image with the new image URL
-             updateChatBox("<strong>ChatLibs: </strong>Here is a link to your story you can share:");
-             updateChatBox("<a target='_blank' href=https://chatlibs.xyz/story?title="+encodeURIComponent(storyData.title)+"&description="+encodeURIComponent(storyData.newStory)+"&image_url="+encodeURIComponent(storyData.imageURL)+">"+storyData.title+"</a>");
-             // Remove the 'image-waiting' class to unhide the image
-             returnImage.classList.remove('image-waiting');
-        }
-
-        currentStep++;
-        getNextPrompt();
-    }
-
-function sendInputToServer(input) {
-    let url = 'api/route'; // Default URL
-    let body = {};
-    let doFetch = false;
-    console.log("Current step: " + currentStep);
-    console.log("Send input to server");
-
-    switch (currentStep) {
-        case 1:            
-            updateChatBox("<strong>ChatLibs: </strong>Thinking about your story...");
-            url = '/write_story';
-            body = { topic: input };
-            console.log(body);
-            doFetch = true;              
-            break;
-        case 2:
-            url = '/get_title';
-            body = { data: storyData.story };
-            console.log(body);
-            doFetch = true;              
-            break;
-        case 3:
-            storyData.adjective1 = input;
-            break;
-        case 4:
-            storyData.noun1 = input;
-            break;
-        case 5:
-             storyData.adjective2 = input;
-            break;
-        case 6:
-            storyData.verb = input;
-            break;
-        case 7:
-            storyData.adjective3 = input;
-            break;
-        case 8:
-            storyData.noun2 = input;
-            updateChatBox("<strong>ChatLibs: </strong>Here we go!...");
-            inputField.classList.add('hidden-element');
-            enterButton.classList.add('hidden-element');
-            url = '/write_newStory';
-            body = {
-                story: storyData.story,
-                adjective1: storyData.adjective1,
-                adjective2: storyData.adjective2,
-                adjective3: storyData.adjective3,
-                noun1: storyData.noun1,
-                noun2: storyData.noun2,
-                verb: storyData.verb
-            };
-            console.log(body);
-            doFetch = true;              
-            break;
-        case 9:
-            updateChatBox("<strong>ChatLibs: </strong>Drawing a picture for you!");
-            url = '/get_image';
-            body = { data: storyData.newStory };
-            console.log(body);
-            doFetch = true;  
-            break;
-        default:
-            break;
-            body = { step: currentStep, input: input, storyData: storyData };
-            break;
-    }
-
-    if (doFetch) {
-      fetch(url, {
-          method: 'POST',
-          body: JSON.stringify(body),
-          headers: {
-              'Content-Type': 'application/json'
-          }
-      })
-      .then(response => response.json())
-      .then(data => handleResponse(data))
-      .catch(error => console.error('Error:', error));
-    } else {
-        handleResponse("No server step");
-    }
-}
-
-    function emphasizeStoryWords() {
-        // Check if the required data exists
-        if (!storyData.newStory || !storyData.adjective1 || !storyData.adjective2 || !storyData.adjective3 || !storyData.noun1 || !storyData.verb || !storyData.noun2 ) {
-            console.error('Missing story data for emphasis');
-            return;
-        }
-
-        // List of words to emphasize
-        const wordsToEmphasize = [storyData.adjective1, storyData.adjective2, storyData.adjective3, storyData.noun1, storyData.verb, storyData.noun2];
-
-        // Create a new story with emphasis
-        let emphasizedStory = storyData.newStory;
-
-        // Replace each word with its emphasized version
-        wordsToEmphasize.forEach(word => {
-            const regex = new RegExp(`\\b${word}\\b`, 'gi'); // Match the word as a whole word, case-insensitive
-            emphasizedStory = emphasizedStory.replace(regex, `<em><strong><u>&nbsp;${word}&nbsp;</u></strong></em>`);
-        });
-
-        // Assign the new story with emphasis to storyData
-        storyData.newStoryWithEmphasis = emphasizedStory;
-    }
-    
-    // Function to handle input submission
-    function handleSubmit() {
-        const userInput = inputField.value;
-        inputField.value = '';
-        // Change button background to grey and disable it
+    function lockInput() {
         enterButton.classList.add('button-waiting');
-        enterButton.disabled=true;
-        inputField.disabled=true;
-        updateChatBox(`<strong>You:</strong> ${userInput}`);
-        sendInputToServer(userInput);
+        enterButton.disabled = true;
+        inputField.disabled = true;
     }
 
-    // Listen for "Enter" key press in the input field
-    inputField.addEventListener('keydown', function(event) {
-        if (event.key === 'Enter') {
-            console.log("type");
-            event.preventDefault(); // Prevent the default form submission behavior
-            if (inputField.value.trim() !== '') {
-                handleSubmit(); // Call the submit function if input is not empty
+    function unlockInput() {
+        enterButton.classList.remove('button-waiting');
+        enterButton.disabled = false;
+        inputField.disabled = false;
+        inputField.focus();
+    }
+
+    function hideInput() {
+        inputField.classList.add('hidden-element');
+        enterButton.classList.add('hidden-element');
+    }
+
+    // --- Server calls -------------------------------------------------------
+
+    async function callApi(url, body) {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        let data = {};
+        try { data = await response.json(); } catch (e) { /* non-JSON error */ }
+        if (!response.ok || data.error) {
+            throw new Error(data.error || `Request failed (${response.status})`);
+        }
+        return data;
+    }
+
+    // --- Word emphasis (highlights the user's words in the swapped story) ---
+
+    function emphasizeStory(story) {
+        let emphasized = story;
+        flow.words.forEach(function (w) {
+            const word = storyData[w.slot];
+            if (!word) return;
+            const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
+            emphasized = emphasized.replace(
+                regex,
+                `<em><strong><u>&nbsp;${word}&nbsp;</u></strong></em>`
+            );
+        });
+        return emphasized;
+    }
+
+    // --- Restart ------------------------------------------------------------
+
+    function offerRestart() {
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = 'Write another story';
+        link.addEventListener('click', function (e) {
+            e.preventDefault();
+            restart();
+        });
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = '<strong>ChatLibs: </strong>';
+        wrapper.appendChild(link);
+        wrapper.innerHTML += '<br><br>';
+        chatBox.appendChild(wrapper);
+        chatBox.scrollTop = chatBox.scrollHeight;
+    }
+
+    function restart() {
+        storyData = {};
+        wordIndex = 0;
+        chatBox.innerHTML = '&nbsp;';
+        returnImage.src = '';
+        returnImage.classList.add('image-waiting');
+        inputField.classList.remove('hidden-element');
+        enterButton.classList.remove('hidden-element');
+        startTopicPhase();
+    }
+
+    // --- Flow phases --------------------------------------------------------
+
+    function startTopicPhase() {
+        phase = 'topic';
+        chatlibsSays(flow.intro);
+        unlockInput();
+    }
+
+    function promptNextWord() {
+        chatlibsSays(flow.words[wordIndex].prompt);
+        unlockInput();
+    }
+
+    async function handleTopic(topic) {
+        chatlibsSays('Thinking about your story...');
+        const storyResp = await callApi('/api/story', { topic: topic });
+        storyData.story = storyResp.story;
+
+        const titleResp = await callApi('/api/title', { story: storyData.story });
+        storyData.title = titleResp.title;
+        chatlibsSays(`Your story is: <br><strong>${storyData.title}</strong>`);
+
+        phase = 'words';
+        wordIndex = 0;
+        promptNextWord();
+    }
+
+    async function finishStory() {
+        phase = 'generating';
+        hideInput();
+        chatlibsSays('Here we go!...');
+
+        const words = {};
+        flow.words.forEach(function (w) { words[w.slot] = storyData[w.slot]; });
+
+        const remixResp = await callApi('/api/remix', {
+            story: storyData.story,
+            words: words
+        });
+        storyData.newStory = remixResp.story;
+
+        updateChatBox(`<br><strong>${storyData.title}</strong><br>`);
+        updateChatBox(emphasizeStory(storyData.newStory));
+
+        chatlibsSays('Drawing a picture for you!');
+        const imageResp = await callApi('/api/image', { story: storyData.newStory });
+        storyData.image = imageResp.image;
+
+        returnImage.src = storyData.image;
+        returnImage.classList.remove('image-waiting');
+
+        const shareUrl = '/story?title=' + encodeURIComponent(storyData.title) +
+            '&description=' + encodeURIComponent(storyData.newStory);
+        chatlibsSays('Here is a link to your story you can share:');
+        updateChatBox(`<a target="_blank" href="${shareUrl}">${storyData.title}</a>`);
+
+        phase = 'done';
+        offerRestart();
+    }
+
+    // --- Input handling -----------------------------------------------------
+
+    async function handleSubmit() {
+        const userInput = inputField.value.trim();
+        if (userInput === '') return;
+        inputField.value = '';
+        updateChatBox(`<strong>You:</strong> ${userInput}`);
+        lockInput();
+
+        try {
+            if (phase === 'topic') {
+                await handleTopic(userInput);
+            } else if (phase === 'words') {
+                storyData[flow.words[wordIndex].slot] = userInput;
+                wordIndex += 1;
+                if (wordIndex < flow.words.length) {
+                    promptNextWord();
+                } else {
+                    await finishStory();
+                }
             }
+        } catch (err) {
+            handleError(err);
+        }
+    }
+
+    function handleError(err) {
+        console.error(err);
+        chatlibsSays(
+            'Oops — something went wrong (' + err.message + '). ' +
+            'Let\'s try that again.'
+        );
+        if (phase === 'generating') {
+            // The story exists but image/remix failed — let them start over.
+            offerRestart();
+        } else {
+            // Recoverable mid-question: re-show the same prompt and re-enable.
+            inputField.classList.remove('hidden-element');
+            enterButton.classList.remove('hidden-element');
+            unlockInput();
+        }
+    }
+
+    inputField.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            handleSubmit();
         }
     });
 
-    // Listen for button click
-    enterButton.addEventListener('click', function() {
-        console.log("click");
-        if (inputField.value.trim() !== '') {
-            handleSubmit(); // Call the submit function if input is not empty
-        }
+    enterButton.addEventListener('click', function () {
+        handleSubmit();
     });
 
-    const inputFields = document.querySelectorAll('input');
-
-    inputFields.forEach(input => {
-        input.addEventListener('focus', () => {
-            document.querySelector('meta[name=viewport]').setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
+    // Mobile: lock zoom while typing, restore on blur (preserved from original).
+    document.querySelectorAll('input').forEach(function (input) {
+        input.addEventListener('focus', function () {
+            document.querySelector('meta[name=viewport]').setAttribute(
+                'content',
+                'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
+            );
         });
-        input.addEventListener('blur', () => {
-            document.querySelector('meta[name=viewport]').setAttribute('content', 'width=device-width, initial-scale=1');
+        input.addEventListener('blur', function () {
+            document.querySelector('meta[name=viewport]').setAttribute(
+                'content', 'width=device-width, initial-scale=1'
+            );
         });
     });
 
+    // --- Boot ---------------------------------------------------------------
 
-    // Start the conversation with the first prompt
-
-    getNextPrompt();
+    lockInput();
+    fetch('/api/config')
+        .then(function (r) { return r.json(); })
+        .then(function (config) {
+            flow = config;
+            startTopicPhase();
+        })
+        .catch(function (err) {
+            console.error(err);
+            chatlibsSays('Could not start the game. Please refresh the page.');
+        });
 });

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -173,5 +173,3 @@ body, html {
 .hidden-element {
     display: none;
 }
-
-

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -27,7 +27,7 @@
 <body>
 <div id="container">
     <div class="header-container">
-<!--   
+<!--
       <img src="path/to/logo.png" alt="Logo" class="logo">
       <ul class="menu">
         <li class="menu-item"><a href="#link1">Menu Item 1</a></li>

--- a/api/templates/story.html
+++ b/api/templates/story.html
@@ -3,32 +3,39 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}"><head>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <title>ChatLibs | {{ title }}</title>
     <meta name="description" content="{{ description }}">
+
+    {% if image_url %}
+      {% set share_image = image_url %}
+    {% else %}
+      {% set share_image = url_for('static', filename='chatlibs-share.png', _external=True) %}
+    {% endif %}
 
     <!-- Facebook Meta Tags -->
     <meta property="og:type" content="website">
     <meta property="og:title" content="{{ title }}">
     <meta property="og:description" content="{{ description }}">
-    <meta property="og:image" content="{{ image_url }}">
+    <meta property="og:image" content="{{ share_image }}">
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@chatlibs">
     <meta name="twitter:title" content="{{ title }}">
     <meta name="twitter:description" content="{{ description }}">
-    <meta name="twitter:image" content="{{ image_url }}">
+    <meta name="twitter:image" content="{{ share_image }}">
 </head>
 <body>
     <h4 id="header_title">Create your own at <a href="https://chatlibs.xyz">ChatLibs.xyz</a></h4>
-    <h1 id="header_title">{{ title }}</h1> <!-- Displaying the title -->
+    <h1 id="header_title">{{ title }}</h1>
     <br>
     <div id="chat_box">
-      {{ description }} <!-- Displaying the story -->
-    </div>  
-    <img src="{{ image_url }}" alt="Story Image" id="return_image"> <!-- Displaying the image -->
+      {{ description }}
+    </div>
+    {% if image_url %}
+    <img src="{{ image_url }}" alt="Story illustration" id="return_image">
+    {% endif %}
     <a target="_blank" href="https://donorschoose.org"><img src="{{ url_for('static', filename='donors-choose-ad.png') }}" alt="Ad Image" id="ad_image"></a>
-<!--    <h3 id="header_title"><a href="https://twitter.com/intent/tweet?text=Check+out+my+story%3A+{{ title }}+on+ChatLibs&url=https://chatlibs.xyz/story?title={{ title }}%26description={{ description }}%26image_url={{ image_url }}">Share this</a></h3> -->
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==3.0.0
-openai==0.28
-requests==2.31.0
+anthropic>=0.40
+google-genai>=0.3

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   ],
   "functions": {
     "api/index.py": {
-      "maxDuration": 120
+      "maxDuration": 60
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   ],
   "functions": {
     "api/index.py": {
-      "maxDuration":120
-    }  
+      "maxDuration": 120
+    }
   }
 }


### PR DESCRIPTION
Replace the OpenAI integration (gpt-4 / dall-e-3 on openai==0.28, both now outdated; DALL-E retired May 2026) with a pluggable AI layer.

- api/ai.py: provider-agnostic text + image backends chosen by env var. Anthropic Claude (claude-sonnet-4-6) for text, Google Imagen 4 for images.
- api/flow.py: game flow (steps, prompts, word slots) as data, served at /api/config so the front end orchestrates off it.
- Stateless endpoints (/api/story, /api/title, /api/remix, /api/image) with a uniform JSON envelope and full error handling (fixes #10-13); add a "write another story" restart (#18).
- Front end look/markup/flow unchanged; script.js rewritten to drive off /api/config with async/await and graceful error handling.
- Story share page falls back to the brand image for social previews.
