### PR TITLE
Fix restart + stray heading, add loading spinner, escape output

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -39,6 +39,17 @@ def _ai_route(produce):
         return jsonify({"error": "Something went wrong. Please try again."}), 502
 
 
+def _strip_heading(text):
+    """Drop a leading Markdown heading line (e.g. '# Title') if the model adds
+    one. The title is generated separately, so a heading in the body just shows
+    up as a stray '# ...' line in the chat (#21)."""
+    text = text.lstrip()
+    if text.startswith("#"):
+        parts = text.split("\n", 1)
+        return parts[1].lstrip() if len(parts) > 1 else ""
+    return text
+
+
 # --- Pages ------------------------------------------------------------------
 
 @app.route("/")
@@ -48,9 +59,16 @@ def index():
 
 @app.route("/story")
 def story():
+    # Only honor an image_url with a safe scheme. The app no longer passes one
+    # (images are ephemeral), but the param is public, so refuse anything that
+    # isn't an https/data URL. Jinja autoescaping covers title/description, and
+    # the client URL-encodes them via encodeURIComponent.
+    image_url = request.args.get("image_url", "")
+    if not (image_url.startswith("https://") or image_url.startswith("data:")):
+        image_url = ""
     return render_template(
         "story.html",
-        image_url=request.args.get("image_url", ""),
+        image_url=image_url,
         title=request.args.get("title", "A ChatLibs Story"),
         description=request.args.get("description", ""),
     )
@@ -72,13 +90,14 @@ def write_story():
         prompt = (
             f"Write a creative, silly 75-word children's story about {topic}. "
             "Include characters, a conflict, rising action, a surprising "
-            "resolution, and a piece of short dialogue. Return only the story."
+            "resolution, and a piece of short dialogue. Do not include a title "
+            "or any heading — return only the story prose."
         )
         story_text = generate_text(
             prompt,
             system="You are a playful children's story writer.",
         )
-        return {"story": story_text}
+        return {"story": _strip_heading(story_text)}
 
     return _ai_route(produce)
 
@@ -120,7 +139,7 @@ def remix_story():
             f"Story:\n{original}\n\n"
             f"Words that must ALL appear:\n{replacements}"
         )
-        return {"story": generate_text(prompt)}
+        return {"story": _strip_heading(generate_text(prompt))}
 
     return _ai_route(produce)
 

--- a/api/static/script.js
+++ b/api/static/script.js
@@ -38,6 +38,26 @@ document.addEventListener('DOMContentLoaded', function () {
         enterButton.classList.add('hidden-element');
     }
 
+    // Escape user- and AI-provided text before it goes into innerHTML, so a
+    // topic/word like "<img onerror=...>" can't inject markup.
+    function escapeHtml(s) {
+        const div = document.createElement('div');
+        div.textContent = s == null ? '' : String(s);
+        return div.innerHTML;
+    }
+
+    function showSpinner() {
+        const div = document.createElement('div');
+        div.innerHTML = '<span class="spinner"></span><br><br>';
+        chatBox.appendChild(div);
+        chatBox.scrollTop = chatBox.scrollHeight;
+        return div;
+    }
+
+    function removeSpinner(div) {
+        if (div && div.parentNode) div.parentNode.removeChild(div);
+    }
+
     // --- Server calls -------------------------------------------------------
 
     async function callApi(url, body) {
@@ -57,23 +77,29 @@ document.addEventListener('DOMContentLoaded', function () {
     // --- Word emphasis (highlights the user's words in the swapped story) ---
 
     function emphasizeStory(story) {
-        let emphasized = story;
+        let html = escapeHtml(story);
         flow.words.forEach(function (w) {
             const word = storyData[w.slot];
             if (!word) return;
-            const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
-            emphasized = emphasized.replace(
-                regex,
-                `<em><strong><u>&nbsp;${word}&nbsp;</u></strong></em>`
-            );
+            // Escape for HTML first, then for regex, so matching happens against
+            // the already-escaped story text.
+            const escWord = escapeHtml(word).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const regex = new RegExp(`\\b${escWord}\\b`, 'gi');
+            // $& re-inserts the matched (escaped) text, preserving its casing.
+            html = html.replace(regex, '<em><strong><u>&nbsp;$&&nbsp;</u></strong></em>');
         });
-        return emphasized;
+        return html;
     }
 
     // --- Restart ------------------------------------------------------------
 
     function offerRestart() {
+        // Build entirely with DOM nodes. The previous version did
+        // `wrapper.innerHTML += '<br><br>'` AFTER appending the link, which
+        // re-parsed the HTML and destroyed the link's click listener (#23).
+        const wrapper = document.createElement('div');
+        const label = document.createElement('strong');
+        label.textContent = 'ChatLibs: ';
         const link = document.createElement('a');
         link.href = '#';
         link.textContent = 'Write another story';
@@ -81,10 +107,10 @@ document.addEventListener('DOMContentLoaded', function () {
             e.preventDefault();
             restart();
         });
-        const wrapper = document.createElement('div');
-        wrapper.innerHTML = '<strong>ChatLibs: </strong>';
+        wrapper.appendChild(label);
         wrapper.appendChild(link);
-        wrapper.innerHTML += '<br><br>';
+        wrapper.appendChild(document.createElement('br'));
+        wrapper.appendChild(document.createElement('br'));
         chatBox.appendChild(wrapper);
         chatBox.scrollTop = chatBox.scrollHeight;
     }
@@ -115,12 +141,17 @@ document.addEventListener('DOMContentLoaded', function () {
 
     async function handleTopic(topic) {
         chatlibsSays('Thinking about your story...');
-        const storyResp = await callApi('/api/story', { topic: topic });
-        storyData.story = storyResp.story;
+        const spinner = showSpinner();
+        try {
+            const storyResp = await callApi('/api/story', { topic: topic });
+            storyData.story = storyResp.story;
 
-        const titleResp = await callApi('/api/title', { story: storyData.story });
-        storyData.title = titleResp.title;
-        chatlibsSays(`Your story is: <br><strong>${storyData.title}</strong>`);
+            const titleResp = await callApi('/api/title', { story: storyData.story });
+            storyData.title = titleResp.title;
+        } finally {
+            removeSpinner(spinner);
+        }
+        chatlibsSays(`Your story is: <br><strong>${escapeHtml(storyData.title)}</strong>`);
 
         phase = 'words';
         wordIndex = 0;
@@ -135,18 +166,28 @@ document.addEventListener('DOMContentLoaded', function () {
         const words = {};
         flow.words.forEach(function (w) { words[w.slot] = storyData[w.slot]; });
 
-        const remixResp = await callApi('/api/remix', {
-            story: storyData.story,
-            words: words
-        });
-        storyData.newStory = remixResp.story;
+        let spinner = showSpinner();
+        try {
+            const remixResp = await callApi('/api/remix', {
+                story: storyData.story,
+                words: words
+            });
+            storyData.newStory = remixResp.story;
+        } finally {
+            removeSpinner(spinner);
+        }
 
-        updateChatBox(`<br><strong>${storyData.title}</strong><br>`);
+        updateChatBox(`<br><strong>${escapeHtml(storyData.title)}</strong><br>`);
         updateChatBox(emphasizeStory(storyData.newStory));
 
         chatlibsSays('Drawing a picture for you!');
-        const imageResp = await callApi('/api/image', { story: storyData.newStory });
-        storyData.image = imageResp.image;
+        spinner = showSpinner();
+        try {
+            const imageResp = await callApi('/api/image', { story: storyData.newStory });
+            storyData.image = imageResp.image;
+        } finally {
+            removeSpinner(spinner);
+        }
 
         returnImage.src = storyData.image;
         returnImage.classList.remove('image-waiting');
@@ -154,7 +195,8 @@ document.addEventListener('DOMContentLoaded', function () {
         const shareUrl = '/story?title=' + encodeURIComponent(storyData.title) +
             '&description=' + encodeURIComponent(storyData.newStory);
         chatlibsSays('Here is a link to your story you can share:');
-        updateChatBox(`<a target="_blank" href="${shareUrl}">${storyData.title}</a>`);
+        updateChatBox('<a target="_blank" href="' + escapeHtml(shareUrl) + '">' +
+            escapeHtml(storyData.title) + '</a>');
 
         phase = 'done';
         offerRestart();
@@ -166,7 +208,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const userInput = inputField.value.trim();
         if (userInput === '') return;
         inputField.value = '';
-        updateChatBox(`<strong>You:</strong> ${userInput}`);
+        updateChatBox('<strong>You:</strong> ' + escapeHtml(userInput));
         lockInput();
 
         try {

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -173,3 +173,19 @@ body, html {
 .hidden-element {
     display: none;
 }
+
+/* Loading spinner shown while the server works (esp. image generation) */
+.spinner {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border: 3px solid #c9d4f3;   /* light brand blue */
+  border-top-color: #98aeea;   /* brand blue (matches the button) */
+  border-radius: 50%;
+  animation: chatlibs-spin 0.8s linear infinite;
+  vertical-align: middle;
+}
+
+@keyframes chatlibs-spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
- #23: "Write Another Story" did nothing. offerRestart() ran `innerHTML += '<br><br>'` after appending the link, which re-parsed the HTML and destroyed the link's click handler. Rebuilt with DOM nodes.
- #21: stories came back with a Markdown "# Title" line that rendered literally in the chat. Tell /api/story not to add a heading, and strip a leading heading defensively (also on remix output).
- #2: show a spinner while the server works (story+title, remix, image).
- #16: escape all user/AI text before it enters innerHTML (fixes a DOM XSS via topic/word input) and only honor https/data image_url on /story. (title/description were already encodeURIComponent'd client-side and Jinja-autoescaped server-side.)