### PR TITLE
Host generated images on Vercel Blob for shareable images (#22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ GOOGLE_API_KEY=...
 # --- Provider selection (rarely changed; here for the abstraction layer) ---
 # TEXT_PROVIDER=anthropic
 # IMAGE_PROVIDER=google
+
+# --- Image hosting (optional; for shareable story-page images) ---
+# Create a Blob store in the Vercel dashboard and it adds this automatically.
+# When unset, images are shown in-app only (inline data URIs).
+# BLOB_READ_WRITE_TOKEN=vercel_blob_rw_...
+# Protects the daily /api/cleanup cron that deletes images older than 30 days.
+# CRON_SECRET=some-long-random-string

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ python api/index.py
 | `IMAGE_MODEL`    | `imagen-4.0-generate-001` | |
 | `TEXT_PROVIDER`  | `anthropic`               | |
 | `IMAGE_PROVIDER` | `google`                  | |
+| `BLOB_READ_WRITE_TOKEN` | —                  | optional; enables durable share-page images via Vercel Blob (auto-added when you create a Blob store). Unset = inline data URIs. |
+| `CRON_SECRET`    | —                         | optional; protects the daily `/api/cleanup` cron |
 
 ## Notes
 
-- Images are returned as `data:` URIs and shown in-app only (ephemeral, by
-  design). The shareable `/story` page carries the title and story text; its
-  social-preview image falls back to the brand share image.
+- Images: with a Vercel Blob store configured (`BLOB_READ_WRITE_TOKEN`), each
+  generated image is uploaded for a durable public URL that the shareable
+  `/story` page and its social preview use; a daily cron (`/api/cleanup`)
+  deletes images older than 30 days. Without Blob configured, images are inline
+  `data:` URIs shown in-app only, and the share page falls back to the brand
+  image.

--- a/api/ai.py
+++ b/api/ai.py
@@ -15,7 +15,6 @@ Env vars:
     GOOGLE_API_KEY  (or GEMINI_API_KEY) required for the google provider
 """
 
-import base64
 import os
 
 TEXT_PROVIDER = os.getenv("TEXT_PROVIDER", "anthropic")
@@ -64,7 +63,10 @@ def _anthropic_text(prompt, system, max_tokens):
 # --- Image ------------------------------------------------------------------
 
 def generate_image(prompt):
-    """Generate an image and return it as a ``data:`` URI for inline display."""
+    """Generate an image and return it as raw JPEG bytes.
+
+    The caller decides how to deliver it (upload to Blob for a durable URL, or
+    inline as a data URI)."""
     if IMAGE_PROVIDER == "google":
         return _google_image(prompt)
     raise AIError(f"Unknown IMAGE_PROVIDER: {IMAGE_PROVIDER!r}")
@@ -96,6 +98,4 @@ def _google_image(prompt):
         # Most commonly a safety filter blocked the prompt.
         raise AIError("No image was generated (it may have been filtered).")
 
-    data = images[0].image.image_bytes
-    b64 = base64.b64encode(data).decode("utf-8")
-    return f"data:image/jpeg;base64,{b64}"
+    return images[0].image.image_bytes

--- a/api/index.py
+++ b/api/index.py
@@ -13,8 +13,11 @@ import sys
 # and the sibling imports below would fail. Add this file's directory explicitly.
 sys.path.insert(0, os.path.dirname(__file__))
 
+import base64
+
 from flask import Flask, jsonify, render_template, request
 
+import storage
 from ai import AIError, generate_image, generate_text
 from flow import FLOW
 
@@ -193,9 +196,36 @@ def get_image():
             "letters, captions, labels, or speech bubbles — a purely wordless "
             f"picture.\n\nScene: {scene}"
         )
-        return {"image": generate_image(prompt)}
+        img_bytes = generate_image(prompt)
+
+        # If Blob storage is configured, upload for a durable public URL (so the
+        # share page can show the image). Otherwise, and on any upload failure,
+        # fall back to an inline data URI shown in-app only.
+        if storage.blob_enabled():
+            try:
+                return {"image": storage.upload_image(img_bytes)}
+            except Exception:
+                app.logger.exception("Blob upload failed; using inline image")
+        b64 = base64.b64encode(img_bytes).decode("utf-8")
+        return {"image": "data:image/jpeg;base64," + b64}
 
     return _ai_route(produce)
+
+
+@app.route("/api/cleanup")
+def cleanup():
+    """Daily Vercel Cron target: delete generated images older than 30 days.
+    Protected by CRON_SECRET when set (Vercel Cron sends it as a Bearer token)."""
+    secret = os.getenv("CRON_SECRET")
+    if secret and request.headers.get("Authorization") != f"Bearer {secret}":
+        return jsonify({"error": "unauthorized"}), 401
+    if not storage.blob_enabled():
+        return jsonify({"deleted": 0, "note": "blob not configured"})
+    try:
+        return jsonify({"deleted": storage.delete_old_images()})
+    except Exception as e:
+        app.logger.exception("Cleanup failed")
+        return jsonify({"error": str(e)}), 500
 
 
 if __name__ == "__main__":

--- a/api/static/script.js
+++ b/api/static/script.js
@@ -192,8 +192,13 @@ document.addEventListener('DOMContentLoaded', function () {
         returnImage.src = storyData.image;
         returnImage.classList.remove('image-waiting');
 
-        const shareUrl = '/story?title=' + encodeURIComponent(storyData.title) +
+        let shareUrl = '/story?title=' + encodeURIComponent(storyData.title) +
             '&description=' + encodeURIComponent(storyData.newStory);
+        // Include the image only if it's a hosted URL (Blob); data URIs are too
+        // big for a query string and won't render in social previews.
+        if (storyData.image && storyData.image.startsWith('http')) {
+            shareUrl += '&image_url=' + encodeURIComponent(storyData.image);
+        }
         chatlibsSays('Here is a link to your story you can share:');
         updateChatBox('<a target="_blank" href="' + escapeHtml(shareUrl) + '">' +
             escapeHtml(storyData.title) + '</a>');

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,0 +1,76 @@
+"""Vercel Blob storage for generated images.
+
+Images are otherwise ephemeral (data URIs shown in-app only), which means the
+shareable /story page has no picture. Uploading to Vercel Blob gives a durable
+public https URL we can put in share links and Open Graph tags.
+
+Vercel Blob has no native object expiry, so delete_old_images() (run daily by a
+Vercel Cron hitting /api/cleanup) prunes anything older than 30 days.
+
+Requires BLOB_READ_WRITE_TOKEN in the environment (auto-added when you create a
+Blob store in the Vercel dashboard). When it's absent, blob_enabled() is False
+and callers fall back to inline data URIs.
+"""
+
+import datetime
+import os
+
+# All ChatLibs images live under this prefix so cleanup never touches anything
+# else in the store.
+PREFIX = "chatlibs/"
+MAX_AGE_DAYS = 30
+
+
+def blob_enabled():
+    return bool(os.getenv("BLOB_READ_WRITE_TOKEN"))
+
+
+def upload_image(data, content_type="image/jpeg"):
+    """Upload JPEG bytes to Vercel Blob; return the public https URL."""
+    import vercel_blob
+
+    resp = vercel_blob.put(
+        PREFIX + "story.jpg",
+        data,
+        {"addRandomSuffix": "true", "contentType": content_type},
+    )
+    return resp["url"]
+
+
+def _parse_uploaded_at(value):
+    """Parse Vercel Blob's ISO-8601 uploadedAt (e.g. '2026-06-28T12:00:00.000Z')."""
+    if isinstance(value, datetime.datetime):
+        return value
+    return datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def delete_old_images(max_age_days=MAX_AGE_DAYS):
+    """Delete ChatLibs blobs older than max_age_days. Returns the count deleted."""
+    import vercel_blob
+
+    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        days=max_age_days
+    )
+    deleted = 0
+    cursor = None
+    while True:
+        opts = {"limit": "1000"}
+        if cursor:
+            opts["cursor"] = cursor
+        result = vercel_blob.list(opts)
+
+        stale = [
+            b["url"]
+            for b in result.get("blobs", [])
+            if b.get("pathname", "").startswith(PREFIX)
+            and _parse_uploaded_at(b["uploadedAt"]) < cutoff
+        ]
+        if stale:
+            vercel_blob.delete(stale)
+            deleted += len(stale)
+
+        if result.get("hasMore") and result.get("cursor"):
+            cursor = result["cursor"]
+        else:
+            break
+    return deleted

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.0
 anthropic>=0.40
 google-genai>=0.3
+vercel_blob>=0.4

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,8 @@
     "api/index.py": {
       "maxDuration": 60
     }
-  }
+  },
+  "crons": [
+    { "path": "/api/cleanup", "schedule": "0 4 * * *" }
+  ]
 }


### PR DESCRIPTION
Generated images were inline data URIs shown in-app only, so the /story share page (and its social preview) had no picture.

- api/storage.py: upload images to Vercel Blob (public https URL) and a delete_old_images() that prunes ChatLibs blobs older than 30 days.
- /api/image now uploads to Blob and returns the durable URL when BLOB_READ_WRITE_TOKEN is set; otherwise falls back to an inline data URI (so local dev and unconfigured deploys still work). ai.generate_image now returns raw bytes; the caller decides delivery.
- /api/cleanup: daily Vercel Cron (vercel.json) that runs the 30-day prune; protected by CRON_SECRET when set.
- script.js: include the hosted image URL in the share link (only when it's an http(s) URL, never a data URI).
- Vercel Blob has no native TTL, hence the cron. No official Python SDK, so this uses the maintained vercel_blob wrapper.