### PR TITLE
Persist story records for short share links (#31)

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -86,17 +86,38 @@ def story():
     # (images are ephemeral), but the param is public, so refuse anything that
     # isn't an https/data URL. Jinja autoescaping covers title/description, and
     # the client URL-encodes them via encodeURIComponent.
-    image_url = request.args.get("image_url", "")
+    sid = request.args.get("id")
+    if sid:
+        # Persisted story (#31): load the record by id.
+        record = storage.load_story(sid) if storage.blob_enabled() else None
+        if record is None:
+            title = "Story not found"
+            description = (
+                "This story link has expired or is invalid. Stories are kept "
+                "for 30 days. Create your own at ChatLibs.xyz!"
+            )
+            words, image_url = [], ""
+        else:
+            title = record.get("title", "A ChatLibs Story")
+            description = record.get("story", "")
+            words = record.get("words", [])
+            image_url = record.get("image_url", "")
+    else:
+        # Self-contained link: everything is in the query string.
+        title = request.args.get("title", "A ChatLibs Story")
+        description = request.args.get("description", "")
+        words = request.args.getlist("w")
+        image_url = request.args.get("image_url", "")
+
     if not (image_url.startswith("https://") or image_url.startswith("data:")):
         image_url = ""
-    description = request.args.get("description", "")
     return render_template(
         "story.html",
         image_url=image_url,
-        title=request.args.get("title", "A ChatLibs Story"),
+        title=title,
         description=description,  # plain text — used in the meta/OG tags
         # emphasized HTML — used for the visible story body (#29)
-        description_html=_emphasize(description, request.args.getlist("w")),
+        description_html=_emphasize(description, words),
     )
 
 
@@ -249,6 +270,26 @@ def cleanup():
     except Exception as e:
         app.logger.exception("Cleanup failed")
         return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/save", methods=["POST"])
+def persist_story():
+    """Persist a story (title/text/words/image) and return a short id for the
+    share link (#31). Returns id=None when Blob isn't configured so the client
+    falls back to a self-contained query-string link."""
+    def produce():
+        data = request.get_json(force=True)
+        if not storage.blob_enabled():
+            return {"id": None}
+        record = {
+            "title": data.get("title", ""),
+            "story": data.get("story", ""),
+            "words": data.get("words", []),
+            "image_url": data.get("image_url", ""),
+        }
+        return {"id": storage.save_story(record)}
+
+    return _ai_route(produce)
 
 
 if __name__ == "__main__":

--- a/api/static/script.js
+++ b/api/static/script.js
@@ -192,18 +192,36 @@ document.addEventListener('DOMContentLoaded', function () {
         returnImage.src = storyData.image;
         returnImage.classList.remove('image-waiting');
 
-        let shareUrl = '/story?title=' + encodeURIComponent(storyData.title) +
-            '&description=' + encodeURIComponent(storyData.newStory);
-        // Include the image only if it's a hosted URL (Blob); data URIs are too
-        // big for a query string and won't render in social previews.
-        if (storyData.image && storyData.image.startsWith('http')) {
-            shareUrl += '&image_url=' + encodeURIComponent(storyData.image);
+        const hostedImage =
+            storyData.image && storyData.image.startsWith('http') ? storyData.image : '';
+
+        // Persist the story for a short, durable share link (#31). If that
+        // isn't available (no Blob, or it errors), fall back to a self-contained
+        // link that carries everything in the query string.
+        let shareUrl = null;
+        try {
+            const saveResp = await callApi('/api/save', {
+                title: storyData.title,
+                story: storyData.newStory,
+                words: flow.words.map(function (w) { return storyData[w.slot]; }),
+                image_url: hostedImage
+            });
+            if (saveResp.id) shareUrl = '/story?id=' + encodeURIComponent(saveResp.id);
+        } catch (e) {
+            console.error('save failed, using inline link', e);
         }
-        // Pass the user's words so the share page can highlight them too (#29).
-        flow.words.forEach(function (w) {
-            const v = storyData[w.slot];
-            if (v) shareUrl += '&w=' + encodeURIComponent(v);
-        });
+        if (!shareUrl) {
+            shareUrl = '/story?title=' + encodeURIComponent(storyData.title) +
+                '&description=' + encodeURIComponent(storyData.newStory);
+            // Include the image only if it's a hosted URL; data URIs are too big
+            // for a query string and won't render in social previews.
+            if (hostedImage) shareUrl += '&image_url=' + encodeURIComponent(hostedImage);
+            // Pass the words so the share page can highlight them too (#29).
+            flow.words.forEach(function (w) {
+                const v = storyData[w.slot];
+                if (v) shareUrl += '&w=' + encodeURIComponent(v);
+            });
+        }
         chatlibsSays('Here is a link to your story you can share:');
         updateChatBox('<a target="_blank" href="' + escapeHtml(shareUrl) + '">' +
             escapeHtml(storyData.title) + '</a>');

--- a/api/storage.py
+++ b/api/storage.py
@@ -13,12 +13,20 @@ and callers fall back to inline data URIs.
 """
 
 import datetime
+import json
 import os
+import re
+import secrets
+import urllib.request
 
-# All ChatLibs images live under this prefix so cleanup never touches anything
-# else in the store.
+# All ChatLibs blobs (images + story records) live under this prefix so cleanup
+# never touches anything else in the store.
 PREFIX = "chatlibs/"
+STORIES_PREFIX = PREFIX + "stories/"
 MAX_AGE_DAYS = 30
+
+# Valid persisted-story id (what we generate); also guards lookups from URLs.
+_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 
 def blob_enabled():
@@ -35,6 +43,35 @@ def upload_image(data, content_type="image/jpeg"):
         {"addRandomSuffix": "true", "contentType": content_type},
     )
     return resp["url"]
+
+
+def save_story(record):
+    """Persist a story record (dict) as JSON; return a short id for the share link.
+    Stored under chatlibs/stories/<id>.json so the 30-day cleanup prunes it too."""
+    import vercel_blob
+
+    sid = secrets.token_urlsafe(9)
+    data = json.dumps(record).encode("utf-8")
+    vercel_blob.put(
+        STORIES_PREFIX + sid + ".json",
+        data,
+        {"contentType": "application/json"},
+    )
+    return sid
+
+
+def load_story(sid):
+    """Load a persisted story record by id, or None if missing/expired/invalid."""
+    import vercel_blob
+
+    if not sid or not _ID_RE.fullmatch(sid):
+        return None
+    pathname = STORIES_PREFIX + sid + ".json"
+    blobs = vercel_blob.list({"prefix": pathname, "limit": "1"}).get("blobs", [])
+    if not blobs:
+        return None
+    with urllib.request.urlopen(blobs[0]["url"]) as resp:
+        return json.loads(resp.read().decode("utf-8"))
 
 
 def _parse_uploaded_at(value):


### PR DESCRIPTION
Previously only the image was persisted; the title/text/words lived only in the share link's query string. Now persist the whole story too.

- storage.py: save_story() writes {title, story, words, image_url} as JSON to chatlibs/stories/<id>.json in Vercel Blob and returns a short id; load_story() reads it back (id validated against traversal). These live under chatlibs/, so the existing 30-day cleanup cron prunes them with their images.
- /api/save: persists a story and returns the id (id=None when Blob isn't configured, so the client falls back to a self-contained link).
- /story now accepts ?id=<id>, loads the record, and renders it (with the #29 word emphasis + image); shows a friendly "expired" message if the record is gone. The query-string form still works as a fallback.
- script.js: save the story and use the short /story?id= link, falling back to the full query-string link if save is unavailable.