### PR TITLE
Trim share bar to Native Share + Copy Link

### DIFF
--- a/api/static/share.js
+++ b/api/static/share.js
@@ -10,24 +10,15 @@
         return b;
     }
 
-    function makeShareLink(label, href, newTab) {
-        const a = document.createElement('a');
-        a.className = 'share-button';
-        a.textContent = label;
-        a.href = href;
-        if (newTab) { a.target = '_blank'; a.rel = 'noopener'; }
-        return a;
-    }
-
     window.buildShareBar = function (opts) {
         const url = opts.url;
         const title = opts.title || '';
-        const imageUrl = opts.imageUrl || '';
 
         const bar = document.createElement('div');
         bar.className = 'share-bar';
 
-        // Native share sheet (mobile / supported browsers only).
+        // Native share sheet — on mobile / supported browsers this covers every
+        // app the user has (Messages, WhatsApp, Mail, social, etc.) in one tap.
         if (navigator.share) {
             bar.appendChild(makeShareButton('📤 Share', function () {
                 navigator.share({ title: 'ChatLibs', text: title, url: url })
@@ -35,7 +26,8 @@
             }));
         }
 
-        // Copy link.
+        // Copy link — the universal fallback that works everywhere, including
+        // browsers without the Web Share API (e.g. Firefox desktop).
         const copyBtn = makeShareButton('🔗 Copy Link', function () {
             navigator.clipboard.writeText(url).then(function () {
                 copyBtn.textContent = '✓ Copied!';
@@ -43,22 +35,6 @@
             }).catch(function () { copyBtn.textContent = 'Copy failed'; });
         });
         bar.appendChild(copyBtn);
-
-        // Email (no new tab — let the mail client open).
-        bar.appendChild(makeShareLink('✉️ Email',
-            'mailto:?subject=' + encodeURIComponent('A ChatLibs story: ' + title) +
-            '&body=' + encodeURIComponent('Check out my silly ChatLibs story: ' + title + '\n\n' + url),
-            false));
-
-        // Facebook (URL only — uses the page's Open Graph tags for the preview).
-        bar.appendChild(makeShareLink('Facebook',
-            'https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(url), true));
-
-        // Pinterest (image-first; include the hosted image when we have one).
-        let pin = 'https://www.pinterest.com/pin/create/button/?url=' +
-            encodeURIComponent(url) + '&description=' + encodeURIComponent(title);
-        if (imageUrl) pin += '&media=' + encodeURIComponent(imageUrl);
-        bar.appendChild(makeShareLink('Pinterest', pin, true));
 
         return bar;
     };


### PR DESCRIPTION
The native share sheet already covers every app on mobile, and Copy Link is the universal fallback for browsers without the Web Share API. Drop the redundant Email, Facebook, and Pinterest buttons. Shared share.js, so both the in-app bar and the /story page update.